### PR TITLE
chore: Add memcached for php7

### DIFF
--- a/bin/webserver/Dockerfile
+++ b/bin/webserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache
+FROM php:7.2-apache
 
 # Update and upgrade the system
 RUN apt-get update && apt-get upgrade -y --no-install-recommends apt-utils
@@ -13,6 +13,28 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     git \
  && rm -rf /var/lib/apt/lists/*
+
+# Memcached
+RUN apt-get update \
+        && buildDeps=" \
+                git \
+                libmemcached-dev \
+                zlib1g-dev \
+        " \
+        && doNotUninstall=" \
+                libmemcached11 \
+                libmemcachedutil2 \
+        " \
+        && apt-get install -y $buildDeps --no-install-recommends \
+        && rm -r /var/lib/apt/lists/* \
+        \
+        && docker-php-source extract \
+        && git clone --branch php7 https://github.com/php-memcached-dev/php-memcached /usr/src/php/ext/memcached/ \
+        && docker-php-ext-install memcached \
+        \
+        && docker-php-source delete \
+        && apt-mark manual $doNotUninstall \
+        && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps
 
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
Install memcached for php7 web server. Method to install is from a
github source. Currently the source only supports up to php7.2
Alternative method is to use pecl memcached package, but requires more
cleanup of temporary packages - messy! See the following link for
updates on the github source:

https://github.com/php-memcached-dev/php-memcached